### PR TITLE
Set Chinese as the default language in the webapp

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,7 +448,7 @@
             }
         };
 
-        let currentLanguage = 'laos';
+        let currentLanguage = 'china';
 
         function renderCards(containerId, cards, options = {}) {
             const container = document.getElementById(containerId);


### PR DESCRIPTION
### Motivation
- Make the webapp load Chinese content by default so users see the Chinese guide on first render.

### Description
- Updated the initial `currentLanguage` value in `index.html` from `'laos'` to `'china'`.

### Testing
- Verified the change with `rg -n "let currentLanguage" index.html` and committed the update; no automated test suite is configured in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf17d9b18832c83611924740dffb2)